### PR TITLE
Support generate JSON report from command line

### DIFF
--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -114,8 +114,8 @@ if (mode === 'server') {
     excludeAssets,
     logger: new Logger(logLevel)
   });
-} else if (mode === 'static') {
-  viewer.generateReport(bundleStats, {
+} else if (mode === 'json') {
+  viewer.generateJSONReport(bundleStats, {
     openBrowser,
     reportFilename: resolve(reportFilename),
     defaultSizes,
@@ -124,7 +124,7 @@ if (mode === 'server') {
     logger: new Logger(logLevel)
   });
 } else {
-  viewer.generateJSONReport(bundleStats, {
+  viewer.generateReport(bundleStats, {
     openBrowser,
     reportFilename: resolve(reportFilename),
     defaultSizes,

--- a/src/bin/analyzer.js
+++ b/src/bin/analyzer.js
@@ -26,9 +26,10 @@ const program = commander
   )
   .option(
     '-m, --mode <mode>',
-    'Analyzer mode. Should be `server` or `static`.' +
+    'Analyzer mode. Should be `server` or `static` or `json`.' +
     br('In `server` mode analyzer will start HTTP server to show bundle report.') +
-    br('In `static` mode single HTML file with bundle report will be generated.'),
+    br('In `static` mode single HTML file with bundle report will be generated.') +
+    br('In `json` mode single JSON file with bundle report will be generated'),
     'server'
   )
   .option(
@@ -85,7 +86,7 @@ let {
 const logger = new Logger(logLevel);
 
 if (!bundleStatsFile) showHelp('Provide path to Webpack Stats file as first argument');
-if (mode !== 'server' && mode !== 'static') showHelp('Invalid mode. Should be either `server` or `static`.');
+if (mode !== 'server' && mode !== 'static' && mode !== 'json') showHelp('Invalid mode. Should be either `server` or `static`.');
 if (mode === 'server' && !host) showHelp('Invalid host name');
 if (mode === 'server' && isNaN(port)) showHelp('Invalid port number');
 if (!SIZES.has(defaultSizes)) showHelp(`Invalid default sizes option. Possible values are: ${[...SIZES].join(', ')}`);
@@ -113,8 +114,17 @@ if (mode === 'server') {
     excludeAssets,
     logger: new Logger(logLevel)
   });
-} else {
+} else if (mode === 'static') {
   viewer.generateReport(bundleStats, {
+    openBrowser,
+    reportFilename: resolve(reportFilename),
+    defaultSizes,
+    bundleDir,
+    excludeAssets,
+    logger: new Logger(logLevel)
+  });
+} else {
+  viewer.generateJSONReport(bundleStats, {
     openBrowser,
     reportFilename: resolve(reportFilename),
     defaultSizes,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -159,7 +159,6 @@ async function generateJSONReport(bundleStats, opts) {
     reportFilename = 'report.json',
     bundleDir = null,
     logger = new Logger(),
-    defaultSizes = 'parsed',
     excludeAssets = null
   } = opts || {};
 
@@ -176,14 +175,18 @@ async function generateJSONReport(bundleStats, opts) {
 
   mkdir.sync(path.dirname(reportFilepath));
 
-  await bfj.write(reportFilepath, report, {
-    space: 2,
-    promises: 'ignore',
-    buffers: 'ignore',
-    maps: 'ignore',
-    iterables: 'ignore',
-    circular: 'ignore'
-  });
+  try {
+    await bfj.write(reportFilepath, report, {
+      space: 2,
+      promises: 'ignore',
+      buffers: 'ignore',
+      maps: 'ignore',
+      iterables: 'ignore',
+      circular: 'ignore'
+    });
+  } catch (err) {
+    return logger.error(err);
+  }
 
   logger.info(
     `${bold('Webpack Bundle Analyzer')} saved report to ${bold(reportFilepath)}`

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -9,6 +9,7 @@ const ejs = require('ejs');
 const opener = require('opener');
 const mkdir = require('mkdirp');
 const { bold } = require('chalk');
+const bfj = require('bfj-node4');
 
 const Logger = require('./Logger');
 const analyzer = require('./analyzer');
@@ -18,6 +19,7 @@ const projectRoot = path.resolve(__dirname, '..');
 module.exports = {
   startServer,
   generateReport,
+  generateJSONReport,
   // deprecated
   start: startServer
 };
@@ -149,6 +151,47 @@ function generateReport(bundleStats, opts) {
       }
     }
   );
+}
+
+async function generateJSONReport(bundleStats, opts) {
+  const {
+    openBrowser = true,
+    reportFilename = 'report.json',
+    bundleDir = null,
+    logger = new Logger(),
+    defaultSizes = 'parsed',
+    excludeAssets = null
+  } = opts || {};
+
+  const report = analyzer.getViewerData(
+    bundleStats,
+    bundleDir,
+    {
+      excludeAssets,
+      logger,
+    }
+  );
+
+  const reportFilepath = path.resolve(bundleDir || process.cwd(), reportFilename);
+
+  mkdir.sync(path.dirname(reportFilepath));
+
+  await bfj.write(reportFilepath, report, {
+    space: 2,
+    promises: 'ignore',
+    buffers: 'ignore',
+    maps: 'ignore',
+    iterables: 'ignore',
+    circular: 'ignore'
+  });
+
+  logger.info(
+    `${bold('Webpack Bundle Analyzer')} saved report to ${bold(reportFilepath)}`
+  );
+
+  if (openBrowser) {
+    opener(`file://${reportFilepath}`);
+  }
 }
 
 function getAssetContent(filename) {


### PR DESCRIPTION
- [x] add `generateJSONReport` for viewer
- [x] BundleAnalyzerPlugin support `mode: json` to generate json report
- [x] BundleAnalyzerPlugin change to use `generateJSONReport` for `report.json`
- [x] analyzer script support `mode: json` to generate json report
  - json report doesn't need to reply on `generateStatsFile`
